### PR TITLE
Full python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,79 @@
-*.~
-*.dot
-*.txt
-*.pyc
-*.html
-*.pickle
-*.inv
-*.js
-*.out
-*doctree*
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
 *.so
-*.swp
-*.o???????
-*.png
-*.pcl
-*.pickle
-*.bk
-src/CMakeFiles/
-src/Makefile
-src/cmake_install.cmake
-build
-backup
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IDE stuff
+/.idea/
+/.project
+/.pydevproject
+/.settings
+*~
+
+# Cython
+cython_debug
+
+# ipython notebook
+.ipynb_checkpoints
+README.txt
+README.rst

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ Installation
 Simply clone the repository:
 
 ```
-git clone https://github.com/ebilionis/py-orthpol.git
+git clone https://github.com/moritzlange/py-orthpol.git
 ```
 
 Go inside the directory and run:
 
 ```
-python setup.py install
+python3 setup.py install
 ```
 
 Demos

--- a/demos/demo1.py
+++ b/demos/demo1.py
@@ -15,12 +15,10 @@ Date:
     3/18/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
 import matplotlib.pyplot as plt
-
 
 # The desired degree
 degree = 4
@@ -29,21 +27,21 @@ degree = 4
 wf = lambda x: 1. / math.sqrt(2. * math.pi) * np.exp(-x ** 2 / 2.)
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
-                                left=-np.inf, right=np.inf, # Domain
-                                wf=wf)
+                                 left=-np.inf, right=np.inf,  # Domain
+                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print ('Number of inputs:', p.num_input)
-print ('Number of outputs:', p.num_output)
+print('Number of inputs:', p.num_input)
+print('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print ('Is normalized:', p.is_normalized)
+print('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print ('Polynomial degree:', p.degree)
+print('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print ('Alpha:', p.alpha)
-print ('Beta:', p.beta)
+print('Alpha:', p.alpha)
+print('Beta:', p.beta)
 # The following should print a description of the polynomial
-print (str(p))
+print(str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-2., 2., 100)
 # Here is the actual evaluation
@@ -55,7 +53,7 @@ plt.title('Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to continue...')
+print('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +63,5 @@ plt.title('Derivatives of Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to end demo...')
+print('Close the window to end demo...')
 plt.show()

--- a/demos/demo1.py
+++ b/demos/demo1.py
@@ -26,24 +26,24 @@ import matplotlib.pyplot as plt
 degree = 4
 
 # The first way of doing it is by directly supplying the weight function.
-wf = lambda(x): 1. / math.sqrt(2. * math.pi) * np.exp(-x ** 2 / 2.)
+wf = lambda x: 1. / math.sqrt(2. * math.pi) * np.exp(-x ** 2 / 2.)
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
                                 left=-np.inf, right=np.inf, # Domain
                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print 'Number of inputs:', p.num_input
-print 'Number of outputs:', p.num_output
+print ('Number of inputs:', p.num_input)
+print ('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print 'Is normalized:', p.is_normalized
+print ('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print 'Polynomial degree:', p.degree
+print ('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print 'Alpha:', p.alpha
-print 'Beta:', p.beta
+print ('Alpha:', p.alpha)
+print ('Beta:', p.beta)
 # The following should print a description of the polynomial
-print str(p)
+print (str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-2., 2., 100)
 # Here is the actual evaluation
@@ -55,7 +55,7 @@ plt.title('Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to continue...'
+print ('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +65,5 @@ plt.title('Derivatives of Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to end demo...'
+print ('Close the window to end demo...')
 plt.show()

--- a/demos/demo10.py
+++ b/demos/demo10.py
@@ -37,17 +37,17 @@ rv = scipy.stats.truncnorm(lower, upper)
 p = orthpol.OrthogonalPolynomial(degree, rv=rv)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print 'Number of inputs:', p.num_input
-print 'Number of outputs:', p.num_output
+print ('Number of inputs:', p.num_input)
+print ('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print 'Is normalized:', p.is_normalized
+print ('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print 'Polynomial degree:', p.degree
+print ('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print 'Alpha:', p.alpha
-print 'Beta:', p.beta
-# The following should print a description of the polynomial
-print str(p)
+print ('Alpha:', p.alpha)
+print ('Beta:', p.beta)
+# The following should print (a description of the polynomial
+print (str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(lower, upper, 100)
 # Here is the actual evaluation
@@ -59,7 +59,7 @@ plt.title('Truncated Normal Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to continue...'
+print ('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -69,5 +69,5 @@ plt.title('Derivatives of Truncated Normal Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to end demo...'
+print ('Close the window to end demo...')
 plt.show()

--- a/demos/demo10.py
+++ b/demos/demo10.py
@@ -17,13 +17,11 @@ Date:
     3/18/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
 import matplotlib.pyplot as plt
 import scipy.stats
-
 
 # The desired degree
 degree = 4
@@ -37,17 +35,17 @@ rv = scipy.stats.truncnorm(lower, upper)
 p = orthpol.OrthogonalPolynomial(degree, rv=rv)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print ('Number of inputs:', p.num_input)
-print ('Number of outputs:', p.num_output)
+print('Number of inputs:', p.num_input)
+print('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print ('Is normalized:', p.is_normalized)
+print('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print ('Polynomial degree:', p.degree)
+print('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print ('Alpha:', p.alpha)
-print ('Beta:', p.beta)
+print('Alpha:', p.alpha)
+print('Beta:', p.beta)
 # The following should print (a description of the polynomial
-print (str(p))
+print(str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(lower, upper, 100)
 # Here is the actual evaluation
@@ -59,7 +57,7 @@ plt.title('Truncated Normal Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to continue...')
+print('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -69,5 +67,5 @@ plt.title('Derivatives of Truncated Normal Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to end demo...')
+print('Close the window to end demo...')
 plt.show()

--- a/demos/demo11.py
+++ b/demos/demo11.py
@@ -24,16 +24,16 @@ degree = 4
 rvs = [scipy.stats.uniform(), scipy.stats.norm()]
 # Then construct the product basis
 p = orthpol.ProductBasis(degree=degree, rvs=rvs)
-# Print info about the polynomials
-print str(p)
+# print (info about the polynomials
+print (str(p))
 # Evaluate the polynomials at some points
 X = np.hstack([rvs[0].rvs(size=(100, 1)), rvs[1].rvs(size=(100, 1))])
 # Look at the shape of X, it should be 100x2:
-print 'X shape:', X.shape
+print ('X shape:', X.shape)
 # Evaluate the polynomials at X
 phi = p(X)
 # Look at the shape of phi, it should be 100xp.num_output
-print 'phi shape:', phi.shape
+print ('phi shape:', phi.shape)
 # Take a look at the phi's also
-print 'phi:'
-print phi
+print ('phi:')
+print (phi)

--- a/demos/demo11.py
+++ b/demos/demo11.py
@@ -8,7 +8,6 @@ Date:
     3/19/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
@@ -25,15 +24,15 @@ rvs = [scipy.stats.uniform(), scipy.stats.norm()]
 # Then construct the product basis
 p = orthpol.ProductBasis(degree=degree, rvs=rvs)
 # print (info about the polynomials
-print (str(p))
+print(str(p))
 # Evaluate the polynomials at some points
 X = np.hstack([rvs[0].rvs(size=(100, 1)), rvs[1].rvs(size=(100, 1))])
 # Look at the shape of X, it should be 100x2:
-print ('X shape:', X.shape)
+print('X shape:', X.shape)
 # Evaluate the polynomials at X
 phi = p(X)
 # Look at the shape of phi, it should be 100xp.num_output
-print ('phi shape:', phi.shape)
+print('phi shape:', phi.shape)
 # Take a look at the phi's also
-print ('phi:')
-print (phi)
+print('phi:')
+print(phi)

--- a/demos/demo2.py
+++ b/demos/demo2.py
@@ -15,35 +15,33 @@ Date:
     3/18/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
 import matplotlib.pyplot as plt
 
-
 # The desired degree
 degree = 4
 
 # The first way of doing it is by directly supplying the weight function.
-wf = lambda x : np.exp(-x)
+wf = lambda x: np.exp(-x)
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
-                                left=0, right=np.inf, # Domain
-                                wf=wf)
+                                 left=0, right=np.inf,  # Domain
+                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print ('Number of inputs:', p.num_input)
-print ('Number of outputs:', p.num_output)
+print('Number of inputs:', p.num_input)
+print('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print ('Is normalized:', p.is_normalized)
+print('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print ('Polynomial degree:', p.degree)
+print('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print ('Alpha:', p.alpha)
-print ('Beta:', p.beta)
+print('Alpha:', p.alpha)
+print('Beta:', p.beta)
 # The following should print (a description of the polynomial
-print (str(p))
+print(str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(0., 2., 100)
 # Here is the actual evaluation
@@ -55,7 +53,7 @@ plt.title('Laguerre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to continue...')
+print('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +63,5 @@ plt.title('Derivatives of Laguerre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to end demo...')
+print('Close the window to end demo...')
 plt.show()

--- a/demos/demo2.py
+++ b/demos/demo2.py
@@ -26,24 +26,24 @@ import matplotlib.pyplot as plt
 degree = 4
 
 # The first way of doing it is by directly supplying the weight function.
-wf = lambda(x): np.exp(-x)
+wf = lambda x : np.exp(-x)
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
                                 left=0, right=np.inf, # Domain
                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print 'Number of inputs:', p.num_input
-print 'Number of outputs:', p.num_output
+print ('Number of inputs:', p.num_input)
+print ('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print 'Is normalized:', p.is_normalized
+print ('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print 'Polynomial degree:', p.degree
+print ('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print 'Alpha:', p.alpha
-print 'Beta:', p.beta
-# The following should print a description of the polynomial
-print str(p)
+print ('Alpha:', p.alpha)
+print ('Beta:', p.beta)
+# The following should print (a description of the polynomial
+print (str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(0., 2., 100)
 # Here is the actual evaluation
@@ -55,7 +55,7 @@ plt.title('Laguerre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to continue...'
+print ('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +65,5 @@ plt.title('Derivatives of Laguerre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to end demo...'
+print ('Close the window to end demo...')
 plt.show()

--- a/demos/demo3.py
+++ b/demos/demo3.py
@@ -26,24 +26,24 @@ import matplotlib.pyplot as plt
 degree = 4
 
 # The first way of doing it is by directly supplying the weight function.
-wf = lambda(x): 1. / np.sqrt(1. - x)
+wf = lambda x: 1. / np.sqrt(1. - x)
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
                                 left=-1., right=1., # Domain
                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print 'Number of inputs:', p.num_input
-print 'Number of outputs:', p.num_output
+print ('Number of inputs:', p.num_input)
+print ('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print 'Is normalized:', p.is_normalized
+print ('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print 'Polynomial degree:', p.degree
+print ('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print 'Alpha:', p.alpha
-print 'Beta:', p.beta
+print ('Alpha:', p.alpha)
+print ('Beta:', p.beta)
 # The following should print a description of the polynomial
-print str(p)
+print (str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-1., 1., 100)
 # Here is the actual evaluation
@@ -55,7 +55,7 @@ plt.title('Chebyshev Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to continue...'
+print ('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +65,5 @@ plt.title('Derivatives of Chebyshev Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to end demo...'
+print ('Close the window to end demo...')
 plt.show()

--- a/demos/demo3.py
+++ b/demos/demo3.py
@@ -15,12 +15,10 @@ Date:
     3/18/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
 import matplotlib.pyplot as plt
-
 
 # The desired degree
 degree = 4
@@ -29,21 +27,21 @@ degree = 4
 wf = lambda x: 1. / np.sqrt(1. - x)
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
-                                left=-1., right=1., # Domain
-                                wf=wf)
+                                 left=-1., right=1.,  # Domain
+                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print ('Number of inputs:', p.num_input)
-print ('Number of outputs:', p.num_output)
+print('Number of inputs:', p.num_input)
+print('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print ('Is normalized:', p.is_normalized)
+print('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print ('Polynomial degree:', p.degree)
+print('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print ('Alpha:', p.alpha)
-print ('Beta:', p.beta)
+print('Alpha:', p.alpha)
+print('Beta:', p.beta)
 # The following should print a description of the polynomial
-print (str(p))
+print(str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-1., 1., 100)
 # Here is the actual evaluation
@@ -55,7 +53,7 @@ plt.title('Chebyshev Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to continue...')
+print('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +63,5 @@ plt.title('Derivatives of Chebyshev Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to end demo...')
+print('Close the window to end demo...')
 plt.show()

--- a/demos/demo4.py
+++ b/demos/demo4.py
@@ -15,12 +15,10 @@ Date:
     3/18/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
 import matplotlib.pyplot as plt
-
 
 # The desired degree
 degree = 4
@@ -31,21 +29,21 @@ alpha = .5
 wf = lambda x: (1. - x ** 2.) ** (alpha - 0.5)
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
-                                left=-1., right=1., # Domain
-                                wf=wf)
+                                 left=-1., right=1.,  # Domain
+                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print ('Number of inputs:', p.num_input)
-print ('Number of outputs:', p.num_output)
+print('Number of inputs:', p.num_input)
+print('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print ('Is normalized:', p.is_normalized)
+print('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print ('Polynomial degree:', p.degree)
+print('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print ('Alpha:', p.alpha)
-print ('Beta:', p.beta)
+print('Alpha:', p.alpha)
+print('Beta:', p.beta)
 # The following should print (a description of the polynomial
-print (str(p))
+print(str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-1., 1., 100)
 # Here is the actual evaluation
@@ -57,7 +55,7 @@ plt.title('Gegenbauer Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to continue...')
+print('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -67,5 +65,5 @@ plt.title('Derivatives of Gegenbauer Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to end demo...')
+print('Close the window to end demo...')
 plt.show()

--- a/demos/demo4.py
+++ b/demos/demo4.py
@@ -28,24 +28,24 @@ degree = 4
 # Pick the alpha and beta of the Gegenbauer polynomials
 alpha = .5
 # The first way of doing it is by directly supplying the weight function.
-wf = lambda(x): (1. - x ** 2.) ** (alpha - 0.5)
+wf = lambda x: (1. - x ** 2.) ** (alpha - 0.5)
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
                                 left=-1., right=1., # Domain
                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print 'Number of inputs:', p.num_input
-print 'Number of outputs:', p.num_output
+print ('Number of inputs:', p.num_input)
+print ('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print 'Is normalized:', p.is_normalized
+print ('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print 'Polynomial degree:', p.degree
+print ('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print 'Alpha:', p.alpha
-print 'Beta:', p.beta
-# The following should print a description of the polynomial
-print str(p)
+print ('Alpha:', p.alpha)
+print ('Beta:', p.beta)
+# The following should print (a description of the polynomial
+print (str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-1., 1., 100)
 # Here is the actual evaluation
@@ -57,7 +57,7 @@ plt.title('Gegenbauer Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to continue...'
+print ('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -67,5 +67,5 @@ plt.title('Derivatives of Gegenbauer Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to end demo...'
+print ('Close the window to end demo...')
 plt.show()

--- a/demos/demo5.py
+++ b/demos/demo5.py
@@ -15,12 +15,10 @@ Date:
     3/18/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
 import matplotlib.pyplot as plt
-
 
 # The desired degree
 degree = 4
@@ -32,21 +30,21 @@ beta = 5.
 wf = lambda x: (1. - x) ** alpha * (1 + x) ** beta
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
-                                left=-1., right=1., # Domain
-                                wf=wf)
+                                 left=-1., right=1.,  # Domain
+                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print ('Number of inputs:', p.num_input)
-print ('Number of outputs:', p.num_output)
+print('Number of inputs:', p.num_input)
+print('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print ('Is normalized:', p.is_normalized)
+print('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print ('Polynomial degree:', p.degree)
+print('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print ('Alpha:', p.alpha)
-print ('Beta:', p.beta)
+print('Alpha:', p.alpha)
+print('Beta:', p.beta)
 # The following should print (a description of the polynomial
-print (str(p))
+print(str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-1., 1., 100)
 # Here is the actual evaluation
@@ -58,7 +56,7 @@ plt.title('Jacobi Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to continue...')
+print('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -68,5 +66,5 @@ plt.title('Derivatives of Jacobi Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to end demo...')
+print('Close the window to end demo...')
 plt.show()

--- a/demos/demo5.py
+++ b/demos/demo5.py
@@ -29,24 +29,24 @@ degree = 4
 alpha = 2.
 beta = 5.
 # The first way of doing it is by directly supplying the weight function.
-wf = lambda(x): (1. - x) ** alpha * (1 + x) ** beta
+wf = lambda x: (1. - x) ** alpha * (1 + x) ** beta
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
                                 left=-1., right=1., # Domain
                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print 'Number of inputs:', p.num_input
-print 'Number of outputs:', p.num_output
+print ('Number of inputs:', p.num_input)
+print ('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print 'Is normalized:', p.is_normalized
+print ('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print 'Polynomial degree:', p.degree
+print ('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print 'Alpha:', p.alpha
-print 'Beta:', p.beta
-# The following should print a description of the polynomial
-print str(p)
+print ('Alpha:', p.alpha)
+print ('Beta:', p.beta)
+# The following should print (a description of the polynomial
+print (str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-1., 1., 100)
 # Here is the actual evaluation
@@ -58,7 +58,7 @@ plt.title('Jacobi Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to continue...'
+print ('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -68,5 +68,5 @@ plt.title('Derivatives of Jacobi Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to end demo...'
+print ('Close the window to end demo...')
 plt.show()

--- a/demos/demo6.py
+++ b/demos/demo6.py
@@ -15,12 +15,10 @@ Date:
     3/18/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
 import matplotlib.pyplot as plt
-
 
 # The desired degree
 degree = 4
@@ -29,21 +27,21 @@ degree = 4
 wf = lambda x: 1.
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
-                                left=0., right=1., # Domain
-                                wf=wf)
+                                 left=0., right=1.,  # Domain
+                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print ('Number of inputs:', p.num_input)
-print ('Number of outputs:', p.num_output)
+print('Number of inputs:', p.num_input)
+print('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print ('Is normalized:', p.is_normalized)
+print('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print ('Polynomial degree:', p.degree)
+print('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print ('Alpha:', p.alpha)
-print ('Beta:', p.beta)
+print('Alpha:', p.alpha)
+print('Beta:', p.beta)
 # The following should print (a description of the polynomial
-print (str(p))
+print(str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(0., 1., 100)
 # Here is the actual evaluation
@@ -55,7 +53,7 @@ plt.title('Legendre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to continue...')
+print('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +63,5 @@ plt.title('Derivatives of Legendre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to end demo...')
+print('Close the window to end demo...')
 plt.show()

--- a/demos/demo6.py
+++ b/demos/demo6.py
@@ -26,24 +26,24 @@ import matplotlib.pyplot as plt
 degree = 4
 
 # The first way of doing it is by directly supplying the weight function
-wf = lambda(x): 1.
+wf = lambda x: 1.
 # Construct it:
 p = orthpol.OrthogonalPolynomial(degree,
                                 left=0., right=1., # Domain
                                 wf=wf)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print 'Number of inputs:', p.num_input
-print 'Number of outputs:', p.num_output
+print ('Number of inputs:', p.num_input)
+print ('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print 'Is normalized:', p.is_normalized
+print ('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print 'Polynomial degree:', p.degree
+print ('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print 'Alpha:', p.alpha
-print 'Beta:', p.beta
-# The following should print a description of the polynomial
-print str(p)
+print ('Alpha:', p.alpha)
+print ('Beta:', p.beta)
+# The following should print (a description of the polynomial
+print (str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(0., 1., 100)
 # Here is the actual evaluation
@@ -55,7 +55,7 @@ plt.title('Legendre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to continue...'
+print ('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +65,5 @@ plt.title('Derivatives of Legendre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to end demo...'
+print ('Close the window to end demo...')
 plt.show()

--- a/demos/demo7.py
+++ b/demos/demo7.py
@@ -16,13 +16,11 @@ Date:
     3/18/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
 import matplotlib.pyplot as plt
 import scipy.stats
-
 
 # The desired degree
 degree = 4
@@ -33,17 +31,17 @@ rv = scipy.stats.uniform()
 p = orthpol.OrthogonalPolynomial(degree, rv=rv)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print ('Number of inputs:', p.num_input)
-print ('Number of outputs:', p.num_output)
+print('Number of inputs:', p.num_input)
+print('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print ('Is normalized:', p.is_normalized)
+print('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print ('Polynomial degree:', p.degree)
+print('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print ('Alpha:', p.alpha)
-print ('Beta:', p.beta)
+print('Alpha:', p.alpha)
+print('Beta:', p.beta)
 # The following should print (a description of the polynomial
-print (str(p))
+print(str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(0., 1., 100)
 # Here is the actual evaluation
@@ -55,7 +53,7 @@ plt.title('Legendre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to continue...')
+print('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +63,5 @@ plt.title('Derivatives of Legendre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to end demo...')
+print('Close the window to end demo...')
 plt.show()

--- a/demos/demo7.py
+++ b/demos/demo7.py
@@ -33,17 +33,17 @@ rv = scipy.stats.uniform()
 p = orthpol.OrthogonalPolynomial(degree, rv=rv)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print 'Number of inputs:', p.num_input
-print 'Number of outputs:', p.num_output
+print ('Number of inputs:', p.num_input)
+print ('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print 'Is normalized:', p.is_normalized
+print ('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print 'Polynomial degree:', p.degree
+print ('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print 'Alpha:', p.alpha
-print 'Beta:', p.beta
-# The following should print a description of the polynomial
-print str(p)
+print ('Alpha:', p.alpha)
+print ('Beta:', p.beta)
+# The following should print (a description of the polynomial
+print (str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(0., 1., 100)
 # Here is the actual evaluation
@@ -55,7 +55,7 @@ plt.title('Legendre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to continue...'
+print ('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +65,5 @@ plt.title('Derivatives of Legendre Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to end demo...'
+print ('Close the window to end demo...')
 plt.show()

--- a/demos/demo8.py
+++ b/demos/demo8.py
@@ -16,13 +16,11 @@ Date:
     3/18/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
 import matplotlib.pyplot as plt
 import scipy.stats
-
 
 # The desired degree
 degree = 4
@@ -33,17 +31,17 @@ rv = scipy.stats.norm()
 p = orthpol.OrthogonalPolynomial(degree, rv=rv)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print ('Number of inputs:', p.num_input)
-print ('Number of outputs:', p.num_output)
+print('Number of inputs:', p.num_input)
+print('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print ('Is normalized:', p.is_normalized)
+print('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print ('Polynomial degree:', p.degree)
+print('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print ('Alpha:', p.alpha)
-print ('Beta:', p.beta)
+print('Alpha:', p.alpha)
+print('Beta:', p.beta)
 # The following should print (a description of the polynomial
-print (str(p))
+print(str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-2., 2., 100)
 # Here is the actual evaluation
@@ -55,7 +53,7 @@ plt.title('Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to continue...')
+print('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +63,5 @@ plt.title('Derivatives of Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to end demo...')
+print('Close the window to end demo...')
 plt.show()

--- a/demos/demo8.py
+++ b/demos/demo8.py
@@ -33,17 +33,17 @@ rv = scipy.stats.norm()
 p = orthpol.OrthogonalPolynomial(degree, rv=rv)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print 'Number of inputs:', p.num_input
-print 'Number of outputs:', p.num_output
+print ('Number of inputs:', p.num_input)
+print ('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print 'Is normalized:', p.is_normalized
+print ('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print 'Polynomial degree:', p.degree
+print ('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print 'Alpha:', p.alpha
-print 'Beta:', p.beta
-# The following should print a description of the polynomial
-print str(p)
+print ('Alpha:', p.alpha)
+print ('Beta:', p.beta)
+# The following should print (a description of the polynomial
+print (str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-2., 2., 100)
 # Here is the actual evaluation
@@ -55,7 +55,7 @@ plt.title('Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to continue...'
+print ('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +65,5 @@ plt.title('Derivatives of Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to end demo...'
+print ('Close the window to end demo...')
 plt.show()

--- a/demos/demo9.py
+++ b/demos/demo9.py
@@ -33,17 +33,17 @@ rv = scipy.stats.norm(loc=-5., scale=2.5)
 p = orthpol.OrthogonalPolynomial(degree, rv=rv)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print 'Number of inputs:', p.num_input
-print 'Number of outputs:', p.num_output
+print ('Number of inputs:', p.num_input)
+print ('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print 'Is normalized:', p.is_normalized
+print ('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print 'Polynomial degree:', p.degree
+print ('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print 'Alpha:', p.alpha
-print 'Beta:', p.beta
-# The following should print a description of the polynomial
-print str(p)
+print ('Alpha:', p.alpha)
+print ('Beta:', p.beta)
+# The following should print (a description of the polynomial
+print (str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-9., -1., 100)
 # Here is the actual evaluation
@@ -55,7 +55,7 @@ plt.title('Shifted Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to continue...'
+print ('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +65,5 @@ plt.title('Derivatives of Shifted Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print 'Close the window to end demo...'
+print ('Close the window to end demo...')
 plt.show()

--- a/demos/demo9.py
+++ b/demos/demo9.py
@@ -16,13 +16,11 @@ Date:
     3/18/2014
 """
 
-
 import orthpol
 import math
 import numpy as np
 import matplotlib.pyplot as plt
 import scipy.stats
-
 
 # The desired degree
 degree = 4
@@ -33,17 +31,17 @@ rv = scipy.stats.norm(loc=-5., scale=2.5)
 p = orthpol.OrthogonalPolynomial(degree, rv=rv)
 # An orthogonal polynomial is though of as a function.
 # Here is how to get the number of inputs and outputs of that function
-print ('Number of inputs:', p.num_input)
-print ('Number of outputs:', p.num_output)
+print('Number of inputs:', p.num_input)
+print('Number of outputs:', p.num_output)
 # Test if the polynomials are normalized (i.e., their norm is 1.):
-print ('Is normalized:', p.is_normalized)
+print('Is normalized:', p.is_normalized)
 # Get the degree of the polynomial:
-print ('Polynomial degree:', p.degree)
+print('Polynomial degree:', p.degree)
 # Get the alpha-beta recursion coefficients:
-print ('Alpha:', p.alpha)
-print ('Beta:', p.beta)
+print('Alpha:', p.alpha)
+print('Beta:', p.beta)
 # The following should print (a description of the polynomial
-print (str(p))
+print(str(p))
 # Now you can evaluate the polynomial at any points you want:
 X = np.linspace(-9., -1., 100)
 # Here is the actual evaluation
@@ -55,7 +53,7 @@ plt.title('Shifted Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel('$p_i(x)$', fontsize=16)
 plt.legend(['$p_{%d}(x)$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to continue...')
+print('Close the window to continue...')
 plt.show()
 # You may also compute the derivatives of the polynomials:
 dphi = p.d(X)
@@ -65,5 +63,5 @@ plt.title('Derivatives of Shifted Hermite Polynomials', fontsize=16)
 plt.xlabel('$x$', fontsize=16)
 plt.ylabel(r'$\frac{dp_i(x)}{dx}$', fontsize=16)
 plt.legend([r'$\frac{p_{%d}(x)}{dx}$' % i for i in range(p.num_output)], loc='best')
-print ('Close the window to end demo...')
+print('Close the window to end demo...')
 plt.show()

--- a/orthpol/__init__.py
+++ b/orthpol/__init__.py
@@ -11,6 +11,6 @@ Date:
 __all__ = ['OrthogonalPolynomial', 'ProductBasis', 'QuadratureRule']
 
 
-import _orthpol
+from . import _orthpol
 from ._quadrature_rule import *
 from ._orthogonal_polynomial import *

--- a/orthpol/__init__.py
+++ b/orthpol/__init__.py
@@ -7,9 +7,7 @@ Date:
     8/10/2013
 """
 
-
 __all__ = ['OrthogonalPolynomial', 'ProductBasis', 'QuadratureRule']
-
 
 from . import _orthpol
 from ._quadrature_rule import *

--- a/orthpol/_lancz.py
+++ b/orthpol/_lancz.py
@@ -7,9 +7,7 @@ Date:
     7/25/2013
 """
 
-
 __all__ = ['lancz']
-
 
 import numpy as np
 from . import _orthpol as orthpol
@@ -33,7 +31,7 @@ def lancz(x, w, n):
 if __name__ == '__main__':
     x = np.linspace(0., 1, 100)
     w = np.ones(100)
-    print (x, w)
+    print(x, w)
     alpha, beta = lancz(x, w, 10)
-    print (alpha)
-    print (beta)
+    print(alpha)
+    print(beta)

--- a/orthpol/_lancz.py
+++ b/orthpol/_lancz.py
@@ -12,7 +12,7 @@ __all__ = ['lancz']
 
 
 import numpy as np
-import _orthpol as orthpol
+from . import _orthpol as orthpol
 
 
 def lancz(x, w, n):
@@ -33,7 +33,7 @@ def lancz(x, w, n):
 if __name__ == '__main__':
     x = np.linspace(0., 1, 100)
     w = np.ones(100)
-    print x, w
+    print (x, w)
     alpha, beta = lancz(x, w, 10)
-    print alpha
-    print beta
+    print (alpha)
+    print (beta)

--- a/orthpol/_orthogonal_polynomial.py
+++ b/orthpol/_orthogonal_polynomial.py
@@ -9,8 +9,6 @@ Date:
 __all__ = ['OrthogonalPolynomial', 'ProductBasis']
 
 import numpy as np
-import math
-import itertools
 from ._quadrature_rule import *
 from ._lancz import *
 from . import _orthpol as orthpol
@@ -273,7 +271,7 @@ class ProductBasis(object):
         # The array cnt stores the number of terms we need to
         # increment for each dimension.
         cnt = np.zeros(num_dim, dtype='i')
-        for j, p in itertools.izip(range(num_dim), self.polynomials):
+        for j, p in zip(range(num_dim), self.polynomials):
             if p.degree >= 1:
                 cnt[j] = 1
 
@@ -289,7 +287,7 @@ class ProductBasis(object):
             # Stores the inde of the term we are copying
             prev = 0
             # Loop over dimensions
-            for j, p in itertools.izip(range(num_dim), self.polynomials):
+            for j, p in zip(range(num_dim), self.polynomials):
                 # Increment orders of cnt[j] terms for dimension j
                 for i in range(cnt[j]):
                     if terms_order[k - 1][prev + i][j] < p.degree:

--- a/orthpol/_orthogonal_polynomial.py
+++ b/orthpol/_orthogonal_polynomial.py
@@ -6,9 +6,7 @@ Date:
     7/25/2013
 """
 
-
 __all__ = ['OrthogonalPolynomial', 'ProductBasis']
-
 
 import numpy as np
 import math
@@ -19,7 +17,6 @@ from . import _orthpol as orthpol
 
 
 class OrthogonalPolynomial(object):
-
     """1D Orthogonal Polynomial via recursive relation.
     A polynomial is of course a function.
     """
@@ -90,7 +87,7 @@ class OrthogonalPolynomial(object):
             name    ---     A name for the polynomial.
         """
         # ToDo: Find a way to provide more than one interval or even delta functions to generate coefficients
-        
+
         self.__name__ = name
         if rv is not None:
             left, right = rv.interval(1)
@@ -144,7 +141,6 @@ class OrthogonalPolynomial(object):
 
 
 class ProductBasis(object):
-
     """A multi-input orthogonal polynomial basis."""
 
     # A container of polynomials
@@ -326,7 +322,7 @@ class ProductBasis(object):
             for j in range(self.num_input):
                 s += str(self.terms[i][j]) + ' '
             s += '\n'
-        s +=  ' num_terms = '
+        s += ' num_terms = '
         for i in range(self.degree + 1):
             s += str(self.num_terms[i]) + ' '
         return s

--- a/orthpol/_orthogonal_polynomial.py
+++ b/orthpol/_orthogonal_polynomial.py
@@ -1,9 +1,7 @@
 """
 Describes an orthogonal polynomial.
-
 Author:
     Ilias Bilionis
-
 Date:
     7/25/2013
 """
@@ -17,13 +15,12 @@ import math
 import itertools
 from ._quadrature_rule import *
 from ._lancz import *
-import _orthpol as orthpol
+from . import _orthpol as orthpol
 
 
 class OrthogonalPolynomial(object):
 
     """1D Orthogonal Polynomial via recursive relation.
-
     A polynomial is of course a function.
     """
 
@@ -74,11 +71,10 @@ class OrthogonalPolynomial(object):
     def num_output(self):
         return self._num_output
 
-    def __init__(self, degree, rv=None, left=-1, right=1, wf=lambda(x): 1.,
+    def __init__(self, degree, rv=None, left=-1, right=1, wf=lambda x: 1.,
                  ncap=50, quad=None,
                  name='Orthogonal Polynomial'):
         """Construct the polynomial.
-
         Keyword Arguments:
             rv      ---     If not None, then it is assumed to be a
                             RandomVariable object which used to define
@@ -93,6 +89,8 @@ class OrthogonalPolynomial(object):
                             one.
             name    ---     A name for the polynomial.
         """
+        # ToDo: Find a way to provide more than one interval or even delta functions to generate coefficients
+        
         self.__name__ = name
         if rv is not None:
             left, right = rv.interval(1)
@@ -101,7 +99,6 @@ class OrthogonalPolynomial(object):
             quad = QuadratureRule(left=left, right=right, wf=wf, ncap=ncap)
         self._alpha, self._beta = lancz(quad.x, quad.w, degree + 1)
         self._gamma = np.ones(self.degree + 1, dtype='float64')
-        self.normalize()
         self._num_input = 1
         self._num_output = self.degree + 1
 
@@ -118,7 +115,6 @@ class OrthogonalPolynomial(object):
 
     def _d_eval(self, x):
         """Evaluate the derivative of the polynomial.
-
         Arguments:
             x   ---     The input point(s).
         """
@@ -196,7 +192,6 @@ class ProductBasis(object):
     def __init__(self, rvs=None, degree=1, polynomials=None, ncap=50,
                  quad=None, name='Product basis'):
         """Initialize the object.
-
         Keyword Argument
             rvs             ---     If not None, then it is assumed to
                                     be a list of random variables.
@@ -233,9 +228,7 @@ class ProductBasis(object):
 
     def _compute_basis_terms(self):
         """Compute the basis terms.
-
         The following is taken from Stokhos.
-
         The approach here for ordering the terms is inductive on the total
         order p.  We get the terms of total order p from the terms of total
         order p-1 by incrementing the orders of the first dimension by 1.
@@ -243,7 +236,6 @@ class ProductBasis(object):
         terms whose first dimension order is 0.  We then repeat for the third
         dimension whose first and second dimension orders are 0, and so on.
         How this is done is most easily illustrated by an example of dimension 3:
-
         Order  terms   cnt  Order  terms   cnt
         0    0 0 0          4    4 0 0  15 5 1
                                  3 1 0

--- a/orthpol/_quadrature_rule.py
+++ b/orthpol/_quadrature_rule.py
@@ -8,9 +8,7 @@ Date:
     7/25/2013
 """
 
-
 __all__ = ['QuadratureRule']
-
 
 import numpy as np
 import math
@@ -56,7 +54,6 @@ def fejer(n, dtype='float64'):
 
 
 class QuadratureRule(object):
-
     """An object representing a quadrature rule."""
 
     # The quadrature points (N x D)
@@ -112,7 +109,7 @@ class QuadratureRule(object):
         When evaluating f(x) with x an N x D matrix,
         then f(x) should be an N x Q matrix.
         """
-        return np.dot(f(self.x).T, self.w) # Q x 1
+        return np.dot(f(self.x).T, self.w)  # Q x 1
 
     def _to_string(self, pad):
         """Return a string representation of the object."""

--- a/orthpol/_quadrature_rule.py
+++ b/orthpol/_quadrature_rule.py
@@ -14,7 +14,7 @@ __all__ = ['QuadratureRule']
 
 import numpy as np
 import math
-import _orthpol as orthpol
+from . import _orthpol as orthpol
 
 
 def symtr(t):
@@ -77,7 +77,7 @@ class QuadratureRule(object):
     def num_quad(self):
         return self._x.shape[0]
 
-    def __init__(self, left=-1, right=1, wf=lambda(x): 1., ncap=500,
+    def __init__(self, left=-1, right=1, wf=lambda x: 1., ncap=500,
                  name='Quadrature Rule'):
         """Construct a quadrature rule.
 
@@ -90,7 +90,7 @@ class QuadratureRule(object):
         """
         x, w = fejer(ncap)
         if wf is None:
-            wf = lambda(x): np.ones(x.shape)
+            wf = lambda x: np.ones(x.shape)
         if math.isinf(left) and math.isinf(right):
             phi, dphi = symtr(x)
             self._x = phi

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from numpy.distutils.core import Extension
 import os
 import glob
 
-
 setup(name='py-orthpol',
       version='1.1',
       description='Construct orthogonal polynomials with respect to arbitrary measures in Python',


### PR DESCRIPTION
The ProductBasis class in the _orthogonal_polynomial module contained some leftover calls to python 2 methods (itertools.izip) and some unused imports. These two things were fixed.